### PR TITLE
Added socket id env for multi GPU configuration

### DIFF
--- a/kubernetes/device-plugin/server.go
+++ b/kubernetes/device-plugin/server.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"net"
 	"os"
+	  "strings"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -218,6 +219,12 @@ func (m *NvshareDevicePlugin) ListAndWatch(e *pluginapi.Empty, s pluginapi.Devic
  */
 func (m *NvshareDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
 	log.SetOutput(os.Stderr)
+ 
+	  socketId:= os.Getenv("NVSHARE_SOCK_ID")
+	  if len(socketId) == 0 {
+		  socketId = "0"
+	  }
+ 
 	responses := pluginapi.AllocateResponse{}
 	for _, req := range reqs.ContainerRequests {
 		for _, id := range req.DevicesIDs {
@@ -249,10 +256,14 @@ func (m *NvshareDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Allo
 			ReadOnly:      true,
 		}
 		mounts = append(mounts, mount)
+  
+		  SocketHostPathNew:= strings.Split(SocketHostPath, ".sock")[0]+socketId+".sock"
+		  SocketContainerPathNew:= strings.Split(SocketContainerPath, ".sock")[0]+socketId+".sock"
+  
 		/* Mount scheduler socket */
 		mount = &pluginapi.Mount{
-			HostPath:      SocketHostPath,
-			ContainerPath: SocketContainerPath,
+			HostPath:      SocketHostPathNew,
+			ContainerPath: SocketContainerPathNew,
 			ReadOnly:      true,
 		}
 		mounts = append(mounts, mount)

--- a/kubernetes/manifests/device-plugin.yaml
+++ b/kubernetes/manifests/device-plugin.yaml
@@ -29,7 +29,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
       - name: nvshare-lib
-        image: docker.io/grgalex/nvshare:libnvshare-v0.1-f654c296
+        image: nvshare:libnvshare-a4301f8e
         command:
         - sleep
         - infinity
@@ -46,6 +46,11 @@ spec:
               - "/bin/sh"
               - "-c"
               - "umount -v /host-var-run-nvshare/libnvshare.so && rm /host-var-run-nvshare/libnvshare.so"
+        env:
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: "1"
+        - name: NVSHARE_SOCK_ID
+          value: "1"
         securityContext:
           # Necessary for mounts to work.
           privileged: true
@@ -58,11 +63,17 @@ spec:
           # mount for /var/run/nvshare/libnvshare.so
           mountPropagation: Bidirectional
       - name: nvshare-device-plugin
-        image: docker.io/grgalex/nvshare:nvshare-device-plugin-v0.1-f654c296
+        image: nvshare:nvshare-device-plugin-a4301f8e
         imagePullPolicy: IfNotPresent
         env:
         - name: NVSHARE_VIRTUAL_DEVICES
           value: "10"
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: "0"
+        - name: NVSHARE_SOCK_ID
+          value: "0"
+        - name: CUDA_VISIBLE_DEVICES
+          value: "0"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -70,9 +81,26 @@ spec:
         volumeMounts:
           - name: device-plugin-socket
             mountPath: /var/lib/kubelet/device-plugins
-        resources:
-          limits:
-            nvidia.com/gpu: 1
+
+      - name: nvshare-device-plugin-1
+        image: nvshare:nvshare-device-plugin-a4301f8e
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NVSHARE_VIRTUAL_DEVICES
+          value: "10"
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: "1"
+        - name: NVSHARE_SOCK_ID
+          value: "1"
+        - name: CUDA_VISIBLE_DEVICES
+          value: "1"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+          - name: device-plugin-socket
+            mountPath: /var/lib/kubelet/device-plugins
       volumes:
         - name: host-var-run-nvshare
           hostPath:

--- a/kubernetes/manifests/scheduler.yaml
+++ b/kubernetes/manifests/scheduler.yaml
@@ -29,7 +29,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
       - name: nvshare-scheduler
-        image: docker.io/grgalex/nvshare:nvshare-scheduler-v0.1-f654c296
+        image: nvshare:nvshare-scheduler-a4301f8e
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -38,6 +38,32 @@ spec:
         volumeMounts:
           - name: nvshare-socket-directory
             mountPath: /var/run/nvshare
+        env:
+          - name: NVIDIA_VISIBLE_DEVICES
+            value: "0"
+          - name: NVSHARE_SOCK_ID
+            value: "0"
+          - name: CUDA_VISIBLE_DEVICES
+            value: "0"
+
+      - name: nvshare-scheduler-1
+        image: nvshare:nvshare-scheduler-a4301f8e
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+          - name: nvshare-socket-directory
+            mountPath: /var/run/nvshare
+        env:
+          - name: NVIDIA_VISIBLE_DEVICES
+            value: "1"
+          - name: NVSHARE_SOCK_ID
+            value: "1"
+          - name: CUDA_VISIBLE_DEVICES
+            value: "1"
+
       volumes:
         - name: nvshare-socket-directory
           hostPath:

--- a/src/comm.c
+++ b/src/comm.c
@@ -80,9 +80,14 @@ int nvshare_get_scheduler_path(char *sock_path)
 
 	offset = ret; /* Start from the trailing NULL byte */
 
+	// get scheduler socket ID
+	char *NVSHARE_SOCK_ID = getenv("NVSHARE_SOCK_ID");
+	if (NVSHARE_SOCK_ID == NULL) {
+		NVSHARE_SOCK_ID = "0";
+	}
 	/* TODO: Ensure it fits in sock_path, check return value */
 	ret = snprintf(sock_path + offset, NVSHARE_SOCK_PATH_MAX - offset,
-			"%s", "scheduler.sock");
+			"%s%s%s", "scheduler",NVSHARE_SOCK_ID,".sock");
 	return 0;
 }
 


### PR DESCRIPTION
Hi @grgalex 

It's been a week and more. We are using the nvshare library in the kubernetes POD and managing the GPU memory across the processes/PODs. It's working fine without any issues. Thank you for making it open for everyone, It's quite useful for GPU based projects.

 Now, we are trying to integrate it with a multi GPU. Basically In a node we have 2 GPUs, we are trying to integrate both the GPUs.


Regarding multi GPU I have experimented with a couple of things-On the repo I went through some issues for multi gpus configuration. Initially I have increased the scheduler and device plugins on the deployment files and deployed the nvhare-system. Then we have deployed our project on the node. As soon as we deployed we got a socket connection error.
After that I did a fork and added an environment variable NVSHARE_SOCK_ID It's basically taking the id of the GPU based on the ID it's creating/connected to the socket. This NVSHARE_SOCK_ID and NVIDIA_VISIBLE_DEVICES we have passed a couple places like `scheduler`, `device-plugins` and the `container's`. This approach is working fine without any issues. In multiple containers we can pass  NVSHARE_SOCK_ID and NVIDIA_VISIBLE_DEVICES based on which GPU we want to process. 
Below some screenshots for config and deployments-

![Screenshot 2024-01-29 at 15 20 35](https://github.com/grgalex/nvshare/assets/25117739/30ec4fe4-8647-4c7d-9f6a-4809b51dc417)
![Screenshot 2024-01-29 at 15 20 50](https://github.com/grgalex/nvshare/assets/25117739/a47ae783-f3e7-45fe-8c36-f0d565956b01)
![Screenshot 2024-01-29 at 15 21 13](https://github.com/grgalex/nvshare/assets/25117739/607a4833-1128-4028-a7a0-591bc6c6a9a4)
![Screenshot 2024-01-29 at 15 22 34](https://github.com/grgalex/nvshare/assets/25117739/2b271101-b752-4b5f-97c0-9d4453dfc687)
![Screenshot 2024-01-29 at 15 23 15](https://github.com/grgalex/nvshare/assets/25117739/e541c6d6-4d8a-4de4-a7b3-2808b3788b58)
![Screenshot 2024-01-29 at 15 26 55](https://github.com/grgalex/nvshare/assets/25117739/c1ad0924-0b24-4a03-b939-54c08b48fb3f)


---
Now we have a another use case- Let's assume In a container we are passing `NVSHARE_SOCK_ID: "0"` and `NVIDIA_VISIBLE_DEVICES: "0"` it means this container will access only the 0'th GPU only. 
In one of the containers there is a single process and two threads are there. Each thread utilizes GPUs by `cudaSetDevice()` in cpp. In normal cases we have to pass `NVIDIA_VISIBLE_DEVICES: "all"` then we can access and map it. But along with nvshare how we will pass and manage the socket for `NVSHARE_SOCK_ID`.

Could you please go through my changes and help with the above problem? 

---
